### PR TITLE
fix dom4j Gradle 6 issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,16 @@ dependencies {
     implementation 'com.sun.jersey.contribs:jersey-apache-client4:1.19.4'
     implementation 'com.sun.jersey.contribs:jersey-multipart:1.19.4'
     implementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    implementation 'org.dom4j:dom4j:2.1.3'
+    implementation('org.dom4j:dom4j:2.1.3') {
+        // workaround for jdom2 bug (https://github.com/dom4j/dom4j/issues/99)
+        // NOTE: a component metadata rule will not solve the problem for library consumers - this is the only way
+        exclude module: 'pull-parser'
+        exclude module: 'jaxen'
+        exclude module: 'xpp3'
+        exclude module: 'xsdlib'
+        exclude module: 'stax-api'
+        exclude module: 'jaxb-api'
+    }
     implementation 'com.emc.vipr:vipr-object-transformations:2.0.3.1'
     implementation 'com.emc.cdp:rest_model:1.0'
     implementation 'org.slf4j:slf4j-api:1.7.32'


### PR DESCRIPTION
build change: excluded some transitives from dom4j due to a bug (https://github.com/dom4j/dom4j/issues/99) that causes SAX parsing issues for consumers using Gradle 6+

same issue as https://github.com/EMCECS/ecs-object-client-java/pull/63